### PR TITLE
Use edge RuboCop for `internal_investigation` task

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -38,7 +38,6 @@ jobs:
       - name: install dependencies
         run: |
           bundle install --jobs 3 --retry 3
-          gem install rubocop rubocop-performance rubocop-rspec
       - name: spec
         run:  bundle exec rake spec
       - name: internal_investigation

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 gemspec
 
 gem 'pry'
@@ -10,6 +12,9 @@ gem 'rspec', '~> 3.7'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.
 # https://github.com/codeclimate/test-reporter/issues/418
+gem 'rubocop', github: 'rubocop-hq/rubocop'
+gem 'rubocop-performance', '~> 1.5.0'
+gem 'rubocop-rspec', '~> 1.33.0'
 gem 'simplecov', '~> 0.10', '< 0.18'
 gem 'test-queue'
 gem 'yard', '~> 0.9'


### PR DESCRIPTION
This configuration reproduces `internal_investigation` task of rubocop-hq/rubocop repo.