### PR TITLE
[Fix rubocop-hq/rubocop-performance#106] Fix RegexpNode#to_regexp 

### DIFF
--- a/lib/rubocop/ast/node/regexp_node.rb
+++ b/lib/rubocop/ast/node/regexp_node.rb
@@ -10,12 +10,15 @@ module RuboCop
         x: Regexp::EXTENDED,
         i: Regexp::IGNORECASE,
         m: Regexp::MULTILINE,
-        n: Regexp::NOENCODING
+        n: Regexp::NOENCODING,
+        o: 0
       }.freeze
 
+      # Note: The 'o' option is ignored.
+      #
       # @return [Regexp] a regexp of this node
       def to_regexp
-        option = regopt.children.map { |opt| OPTIONS[opt] }.inject(:|)
+        option = regopt.children.map { |opt| OPTIONS.fetch(opt) }.inject(:|)
         Regexp.new(content, option)
       end
 

--- a/spec/rubocop/ast/regexp_node_spec.rb
+++ b/spec/rubocop/ast/regexp_node_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe RuboCop::AST::RegexpNode do
       it { expect(regexp_node.to_regexp).to eq(eval(source)) }
     end
     # rubocop:enable Security/Eval
+
+    context 'with a regexp with an "o" option' do
+      let(:source) { '/abc/io' }
+
+      it { expect(regexp_node.to_regexp.inspect).to eq('/abc/i') }
+    end
   end
 
   describe '#regopt' do


### PR DESCRIPTION
where option is 'o' + any other