### PR TITLE
Fix rubocop offense for redundant regex escape

### DIFF
--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -119,7 +119,7 @@ module RuboCop
         ).freeze
         NUMBER       = /-?\d+(?:\.\d+)?/.freeze
         STRING       = /".+?"/.freeze
-        METHOD_NAME  = /\#?#{IDENTIFIER}[\!\?]?\(?/.freeze
+        METHOD_NAME  = /\#?#{IDENTIFIER}[!?]?\(?/.freeze
         PARAM_NUMBER = /%\d*/.freeze
 
         SEPARATORS = /[\s]+/.freeze


### PR DESCRIPTION
Example failure: https://github.com/rubocop-hq/rubocop-ast/pull/15/checks?check_run_id=724719610