### PR TITLE
Fix regex offense reported by rubocop

### DIFF
--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -122,7 +122,7 @@ module RuboCop
         METHOD_NAME  = /\#?#{IDENTIFIER}[!?]?\(?/.freeze
         PARAM_NUMBER = /%\d*/.freeze
 
-        SEPARATORS = /[\s]+/.freeze
+        SEPARATORS = /\s+/.freeze
         TOKENS     = Regexp.union(META, PARAM_NUMBER, NUMBER,
                                   METHOD_NAME, SYMBOL, STRING)
 


### PR DESCRIPTION
Example failure: https://github.com/rubocop-hq/rubocop-ast/pull/18/checks?check_run_id=728073363