### PR TITLE
CI: add full run specs for main RuboCop repo

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  main:
+  ast_specs:
     name: >-
       ${{ matrix.ruby }} | RuboCop ${{ matrix.rubocop }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
@@ -54,3 +54,33 @@ jobs:
       - name: internal_investigation
         if: matrix.os != 'windows'
         run:  bundle exec rake internal_investigation
+  rubocop_specs:
+    name: >-
+      Full specs ${{ matrix.ruby }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      # See https://github.com/tmm1/test-queue#environment-variables
+      TEST_QUEUE_WORKERS: 2
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu ]
+        ruby: [ 2.4, 2.7 ]
+        rubocop: [ master ]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: install dependencies
+        run: bundle install --jobs 3 --retry 3
+      - name: install rubocop from source for internal investigation
+        run: |
+          git clone https://github.com/rubocop-hq/rubocop.git ../rubocop
+          chmod +x ../rubocop/exe/rubocop
+          cd ../rubocop && bundle install --jobs 3 --retry 3
+      - name: spec
+        run:  cd ../rubocop && bundle exec rake spec


### PR DESCRIPTION
This should actually fail because of #20 