### PR TITLE
NodePattern: Add Constants and keyword parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#41](https://github.com/rubocop-hq/rubocop-ast/pull/41): Add `delimiters` and related predicates for `RegexpNode`. ([@owst][])
 * [#46](https://github.com/rubocop-hq/rubocop-ast/pull/46): Basic support for [non-legacy AST output from parser](https://github.com/whitequark/parser/#usage). Note that there is no support (yet) in main RuboCop gem. ([@marcandre][])
 * [#48](https://github.com/rubocop-hq/rubocop-ast/pull/48): Support `Parser::Ruby28` for Ruby 2.8 (3.0) parser. ([@koic][])
+* [#35](https://github.com/rubocop-hq/rubocop-ast/pull/35): NodePattern now accepts `%named_param` and `%CONST`. The macros `def_node_pattern` and `def_node_search` accept default named parameters. ([@marcandre][])
 
 ## 0.0.3 (2020-05-15)
 

--- a/docs/modules/ROOT/pages/node_pattern.adoc
+++ b/docs/modules/ROOT/pages/node_pattern.adoc
@@ -413,6 +413,29 @@ NOTE: `Array#===` will never match a single node element (so don't pass arrays),
 but `Set#===` is an alias to `Set#include?` (Ruby 2.5+ only), and so can be
 very useful to match within many possible literals / Nodes.
 
+== `%param_name` for named parameters
+
+Arguments can be passed as named parameters. They will be matched using `===`
+(see `%` above).
+
+Contrary to positional arguments, defaults values can be passed to
+`def_node_matcher` and `def_node_search`:
+
+[source,ruby]
+----
+def_node_matcher :interesting_call?, '(send _ %method ...)',
+                 method: Set[:transform_values, :transform_keys,
+                             :transform_values!, :transform_keys!,
+                             :to_h].freeze
+
+# Usage:
+
+interesting_call?(node) # use the default methods
+interesting_call?(node, method: /^transform/) # match anything starting with 'transform'
+----
+
+Named parameters as arguments to custom methods are also supported.
+
 == `nil` or `nil?`
 
 Take a special attention to nil behavior:

--- a/docs/modules/ROOT/pages/node_pattern.adoc
+++ b/docs/modules/ROOT/pages/node_pattern.adoc
@@ -436,6 +436,23 @@ interesting_call?(node, method: /^transform/) # match anything starting with 'tr
 
 Named parameters as arguments to custom methods are also supported.
 
+== `%CONST` for constants
+
+Constants can be included in patterns. They will be matched using `===`, so
++Regexp+ / +Set+ / +Proc+ can be used in addition to literals and +Nodes+:
+
+[source,ruby]
+----
+SOME_CALLS = Set[:transform_values, :transform_keys,
+                 :transform_values!, :transform_keys!,
+                 :to_h].freeze
+
+def_node_matcher :interesting_call?, '(send _ %SOME_CALLS ...)'
+
+----
+
+Constants as arguments to custom methods are also supported.
+
 == `nil` or `nil?`
 
 Take a special attention to nil behavior:

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -1162,6 +1162,25 @@ RSpec.describe RuboCop::AST::NodePattern do
       end
     end
 
+    context 'with a constant argument' do
+      let(:pattern) { '(send (int equal?(%CONST)) ...)' }
+      let(:ruby) { '1 + 2' }
+
+      before { stub_const 'CONST', const_value }
+
+      context 'for which the predicate is true' do
+        let(:const_value) { 1 }
+
+        it_behaves_like 'matching'
+      end
+
+      context 'for which the predicate is false' do
+        let(:const_value) { 2 }
+
+        it_behaves_like 'nonmatching'
+      end
+    end
+
     context 'with multiple arguments' do
       let(:pattern) { '(str between?(%1, %2))' }
       let(:ruby) { '"c"' }
@@ -2101,6 +2120,21 @@ RSpec.describe RuboCop::AST::NodePattern do
             end
           end
         end
+      end
+    end
+
+    context 'with a pattern with a constant' do
+      let(:pattern) { '(sym %TEST)' }
+      let(:helper_name) { :def_node_matcher }
+
+      before { defined_class::TEST = hello_matcher }
+
+      it_behaves_like 'matching'
+
+      context 'when the value is not in the set' do
+        let(:ruby) { ':world' }
+
+        it_behaves_like 'nonmatching'
       end
     end
   end


### PR DESCRIPTION
This PR allows use of constants in a `NodePattern`, and allows keyword parameters (in addition to the existing sequential parameters).

Example [from the main gem](https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/cop/lint/useless_comparison.rb#L15-L18)

```ruby
-       OPS = %w[== === != < > <= >= <=>].freeze
+       OPS = %i[== === != < > <= >= <=>].to_set.freeze

        def_node_matcher :useless_comparison?,
-                        "(send $_match {:#{OPS.join(' :')}} $_match)"
+                        "(send $_match %OPS $_match)"
```

This would also be faster (doing a single hash lookup instead of 8 comparisons, see #29)

The keyword parameters is for cases where positional parameters wouldn't be as clear, but also because I would like to make it possible to specify some keyword parameters at the definition too (upcoming PR)

For example, if one doesn't care to define a constant, one could write:

```ruby
       def_node_matcher :useless_comparison?,
-                         "(send $_match {:#{OPS.join(' :')}} $_match)"
+                         "(send $_match %ops $_match)",
+                         ops: %i[== === != < > <= >= <=>].to_set.freeze
```

This could be overridden when calling the matcher, e.g.
```ruby
useless_comparison?(node, ops: ...)
```
