### PR TITLE
Add `enumerable_method?` for `MethodIdentifierPredicates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#37](https://github.com/rubocop-hq/rubocop-ast/pull/37): Add `enumerable_method?` for `MethodIdentifierPredicates`. ([@fatkodima][])
 * [#4](https://github.com/rubocop-hq/rubocop-ast/issues/4): Add `interpolation?` for `RegexpNode`. ([@tejasbubane][])
 * [#20](https://github.com/rubocop-hq/rubocop-ast/pull/20): Add option predicates for `RegexpNode`. ([@owst][])
 * [#11](https://github.com/rubocop-hq/rubocop-ast/issues/11): Add `argument_type?` method to make it easy to recognize argument nodes. ([@tejasbubane][])
@@ -32,3 +33,4 @@
 
 [@marcandre]: https://github.com/marcandre
 [@owst]: https://github.com/owst
+[@fatkodima]: https://github.com/fatkodima

--- a/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
+++ b/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
@@ -12,6 +12,8 @@ module RuboCop
                               map reduce reject reject! reverse_each select
                               select! times upto].freeze
 
+      ENUMERABLE_METHODS = (Enumerable.instance_methods + [:each]).freeze
+
       # http://phrogz.net/programmingruby/language.html#table_18.4
       OPERATOR_METHODS = %i[| ^ & <=> == === =~ > >= < <= << >> + - * /
                             % ** ~ +@ -@ !@ ~@ [] []= ! != !~ `].freeze
@@ -51,6 +53,13 @@ module RuboCop
       def enumerator_method?
         ENUMERATOR_METHODS.include?(method_name) ||
           method_name.to_s.start_with?('each_')
+      end
+
+      # Checks whether the method is an Enumerable method.
+      #
+      # @return [Boolean] whether the method is an Enumerable method
+      def enumerable_method?
+        ENUMERABLE_METHODS.include?(method_name)
       end
 
       # Checks whether the method is a predicate method.

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -782,6 +782,21 @@ RSpec.describe RuboCop::AST::SendNode do
     end
   end
 
+  describe '#enumerable_method?' do
+    context 'with an enumerable method' do
+      let(:send_node) { parse_source(source).ast.send_node }
+      let(:source) { 'foo.all? { |e| bar?(e) }' }
+
+      it { expect(send_node.enumerable_method?).to be_truthy }
+    end
+
+    context 'with a regular method' do
+      let(:source) { 'foo.bar(:baz)' }
+
+      it { expect(send_node.enumerable_method?).to be_falsey }
+    end
+  end
+
   describe '#attribute_accessor?' do
     context 'with an accessor' do
       let(:source) { 'attr_reader :foo, bar, *baz' }


### PR DESCRIPTION
For context - https://github.com/rubocop-hq/rubocop-performance/pull/140/files#r439732580

This was already needed several times: [one](https://github.com/rubocop-hq/rubocop-performance/pull/140/files#diff-81a815a5887c41f8974ad4d9d34d11f7R41), [two](https://github.com/rubocop-hq/rubocop-performance/pull/127/files#diff-6e1da1392214a67f5b4f8919f93f9b20R31)