### PR TITLE
Run internal investigation using master only. Fix disabling

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -66,7 +66,7 @@ jobs:
         if: matrix.coverage != true
         run:  bundle exec rake spec
       - name: internal_investigation
-        if: "matrix.os != 'windows' && matrix.coverage != true"
+        if: "matrix.os != 'windows' && matrix.coverage != true && matrix.rubocop == 'master'"
         run:  bundle exec rake internal_investigation
   rubocop_specs:
     name: >-

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -505,7 +505,7 @@ module RuboCop
       # So, does the return value of this node matter? If we changed it to
       # `(...; nil)`, might that affect anything?
       #
-      # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength
       def value_used?
         # Be conservative and return true if we're not sure.
         return false if parent.nil?
@@ -527,7 +527,7 @@ module RuboCop
           true
         end
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/MethodLength
 
       # Some expressions are evaluated for their value, some for their side
       # effects, and some for both.


### PR DESCRIPTION
There are cases where it won't be possible to pass internal investigation for both `master` and official rubocop (like now that CyclomaticComplexity has been tweaked), so run internal investigation only on `master`.