### PR TITLE
Support "Endless method definition" syntax for Ruby 2.8 (3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#49](https://github.com/rubocop-hq/rubocop-ast/pull/49): Support "Endless method definition" syntax for Ruby 2.8 (3.0). ([@koic][])
+
 ## 0.1.0 (2020-06-26)
 
 ### New features

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -26,6 +26,7 @@ module RuboCop
         case:         CaseNode,
         class:        ClassNode,
         def:          DefNode,
+        def_e:        DefNode,
         defined?:     DefinedNode,
         defs:         DefNode,
         ensure:       EnsureNode,

--- a/lib/rubocop/ast/node/def_node.rb
+++ b/lib/rubocop/ast/node/def_node.rb
@@ -27,6 +27,15 @@ module RuboCop
         arguments.any?(&:forward_args_type?) || arguments.any?(&:forward_arg_type?)
       end
 
+      # Checks whether this is an endless method definition node
+      # as per the feature added in Ruby 2.8.
+      #
+      # @note This is written in a way that may support method definition
+      #       which are rumored to be added in a later version of Ruby.
+      #
+      # @return [Boolean] whether the `def_s` node
+      alias endless? def_e_type?
+
       # The name of the defined method as a symbol.
       #
       # @return [Symbol] the name of the defined method

--- a/spec/rubocop/ast/def_node_spec.rb
+++ b/spec/rubocop/ast/def_node_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe RuboCop::AST::DefNode do
 
       it { expect(def_node.is_a?(described_class)).to be(true) }
     end
+
+    context 'with a def_e node', :ruby28 do
+      let(:source) { 'def foo() = 42' }
+
+      it { expect(def_node.is_a?(described_class)).to be(true) }
+    end
   end
 
   describe '#method_name' do
@@ -40,6 +46,12 @@ RSpec.describe RuboCop::AST::DefNode do
       let(:source) { 'def -@; end' }
 
       it { expect(def_node.method_name).to eq(:-@) }
+    end
+
+    context 'with endless method definition', :ruby28 do
+      let(:source) { 'def foo() = 42' }
+
+      it { expect(def_node.method_name).to eq(:foo) }
     end
   end
 
@@ -108,6 +120,12 @@ RSpec.describe RuboCop::AST::DefNode do
       let(:source) { 'def foo(...); end' }
 
       it { expect(def_node.arguments.size).to eq(1) }
+    end
+
+    context 'with endless method definition', :ruby28 do
+      let(:source) { 'def foo(bar, baz) = 42' }
+
+      it { expect(def_node.arguments.size).to eq(2) }
     end
   end
 
@@ -354,6 +372,20 @@ RSpec.describe RuboCop::AST::DefNode do
       let(:source) { 'def foo(...); end' }
 
       it { expect(def_node.argument_forwarding?).to be_truthy }
+    end
+  end
+
+  context 'when using Ruby 2.8 or newer', :ruby28 do
+    context 'with endless method definition', :ruby28 do
+      let(:source) { 'def foo() = 42' }
+
+      it { expect(def_node.endless?).to be(true) }
+    end
+
+    context 'with normal method definition' do
+      let(:source) { 'def foo; end' }
+
+      it { expect(def_node.endless?).to be(false) }
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,10 @@ RSpec.shared_context 'ruby 2.7', :ruby27 do
   let(:ruby_version) { 2.7 }
 end
 
+RSpec.shared_context 'ruby 2.8', :ruby28 do
+  let(:ruby_version) { 2.8 }
+end
+
 module DefaultRubyVersion
   extend RSpec::SharedContext
 


### PR DESCRIPTION
This PR supports "Endless method definition" syntax for Ruby 2.8 (3.0).
Parser gem supports this syntax by https://github.com/whitequark/parser/pull/676.

Ref: https://bugs.ruby-lang.org/issues/16746