### PR TITLE
Support find pattern for pattern matching syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#50](https://github.com/rubocop-hq/rubocop-ast/pull/50): Support find pattern matching for Ruby 2.8 (3.0) parser. ([@koic][])
+
 ## 0.1.0 (2020-06-26)
 
 ### New features

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -34,7 +34,7 @@ module RuboCop
                              match_with_lvasgn begin kwbegin return
                              in_match match_alt
                              match_as array_pattern array_pattern_with_tail
-                             hash_pattern const_pattern
+                             hash_pattern const_pattern find_pattern
                              index indexasgn].freeze
       SECOND_CHILD_ONLY = %i[lvasgn ivasgn cvasgn gvasgn optarg kwarg
                              kwoptarg].freeze


### PR DESCRIPTION
This PR Support find pattern matching for Ruby 2.8 (3.0) parser.
Parser gem supports this syntax by https://github.com/whitequark/parser/pull/714.