### PR TITLE
Deprecate all `each_...` and `find_...` that add no value

### DIFF
--- a/lib/rubocop/ast/node/array_node.rb
+++ b/lib/rubocop/ast/node/array_node.rb
@@ -18,11 +18,7 @@ module RuboCop
         each_child_node.to_a
       end
 
-      # Calls the given block for all values in the `array` literal.
-      #
-      # @yieldparam [Node] node each node
-      # @return [self] if a block is given
-      # @return [Enumerator] if no block is given
+      # @deprecated Use `values.each` (a.k.a. `children.each`)
       def each_value(&block)
         return to_enum(__method__) unless block_given?
 

--- a/lib/rubocop/ast/node/case_match_node.rb
+++ b/lib/rubocop/ast/node/case_match_node.rb
@@ -15,11 +15,7 @@ module RuboCop
         'case'
       end
 
-      # Calls the given block for each `in_pattern` node in the `in` statement.
-      # If no block is given, an `Enumerator` is returned.
-      #
-      # @return [self] if a block is given
-      # @return [Enumerator] if no block is given
+      # @deprecated Use `in_pattern_branches.each`
       def each_in_pattern
         return in_pattern_branches.to_enum(__method__) unless block_given?
 

--- a/lib/rubocop/ast/node/case_node.rb
+++ b/lib/rubocop/ast/node/case_node.rb
@@ -15,11 +15,7 @@ module RuboCop
         'case'
       end
 
-      # Calls the given block for each `when` node in the `case` statement.
-      # If no block is given, an `Enumerator` is returned.
-      #
-      # @return [self] if a block is given
-      # @return [Enumerator] if no block is given
+      # @deprecated Use `when_branches.each`
       def each_when
         return when_branches.to_enum(__method__) unless block_given?
 

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -158,11 +158,7 @@ module RuboCop
         branches.concat(other_branches)
       end
 
-      # Calls the given block for each branch node in the conditional statement.
-      # If no block is given, an `Enumerator` is returned.
-      #
-      # @return [self] if a block is given
-      # @return [Enumerator] if no block is given
+      # @deprecated Use `branches.each`
       def each_branch
         return branches.to_enum(__method__) unless block_given?
 

--- a/lib/rubocop/ast/node/when_node.rb
+++ b/lib/rubocop/ast/node/when_node.rb
@@ -13,11 +13,7 @@ module RuboCop
         node_parts[0...-1]
       end
 
-      # Calls the given block for each condition node in the `when` branch.
-      # If no block is given, an `Enumerator` is returned.
-      #
-      # @return [self] if a block is given
-      # @return [Enumerator] if no block is given
+      # @deprecated Use `conditions.each`
       def each_condition
         return conditions.to_enum(__method__) unless block_given?
 

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -71,18 +71,22 @@ module RuboCop
         Digest::SHA1.hexdigest(@raw_source)
       end
 
+      # @deprecated Use `comments.each`
       def each_comment
         comments.each { |comment| yield comment }
       end
 
+      # @deprecated Use `comments.find`
       def find_comment
         comments.find { |comment| yield comment }
       end
 
+      # @deprecated Use `tokens.each`
       def each_token
         tokens.each { |token| yield token }
       end
 
+      # @deprecated Use `tokens.find`
       def find_token
         tokens.find { |token| yield token }
       end


### PR DESCRIPTION
These enumerating methods have only disadvantages compared to
the equivalent `conditions.each` / `values.each`. Mainly they are
less clear to a reader not familiar with them (higher cognitive load)
and offer no benefit (and are always less efficient)

Some also don't return an enumerator if called without a block.

Methods `find_...` feel even weaker; will we introduce `any_...`, `all_...`, `map_...`, etc? This is an anti-pattern.

Deprecation is documentation only; I don't feel it's worth actually warning / eventually removing them.