### PR TITLE
Fix `ProcessedSource#commented?` for multi-line ranges. Add `ProcessedSource#commented_line?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### New features
 
 * [#50](https://github.com/rubocop-hq/rubocop-ast/pull/50): Support find pattern matching for Ruby 2.8 (3.0) parser. ([@koic][])
+* [#55](https://github.com/rubocop-hq/rubocop-ast/pull/55): Add `ProcessedSource#line_with_comment?`. ([@marcandre][])
+
+### Bug fixes
+
+* [#55](https://github.com/rubocop-hq/rubocop-ast/pull/55): Fix `ProcessedSource#commented?` for multi-line ranges. Renamed `contains_comment?` ([@marcandre][])
 
 ## 0.1.0 (2020-06-26)
 

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -99,9 +99,19 @@ module RuboCop
         ast.nil?
       end
 
-      def commented?(source_range)
-        comment_lines.include?(source_range.line)
+      # @return [Boolean] if the given line number has a comment.
+      def line_with_comment?(line)
+        comment_lines.include?(line)
       end
+
+      # @return [Boolean] if any of the lines in the given `source_range` has a comment.
+      def contains_comment?(source_range)
+        (source_range.line..source_range.last_line).any? do |line|
+          line_with_comment?(line)
+        end
+      end
+      # @deprecated use contains_comment?
+      alias commented? contains_comment?
 
       def comments_before_line(line)
         comments.select { |c| c.location.line <= line }

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -252,23 +252,23 @@ RSpec.describe RuboCop::AST::ProcessedSource do
     end
 
     describe '#commented?' do
+      subject(:commented) { processed_source.commented?(range) }
+
       let(:source) { <<~RUBY }
         # comment
         [ 1, 2 ]
       RUBY
 
-      context 'provided source_range on line with comment' do
-        it 'returns true' do
-          bracket_range = processed_source.find_token(&:left_bracket?).pos
-          expect(processed_source.commented?(bracket_range)).to be false
-        end
+      context 'provided source_range on line without comment' do
+        let(:range) { processed_source.find_token(&:left_bracket?).pos }
+
+        it { is_expected.to be false }
       end
 
-      context 'provided source_range on line without comment' do
-        it 'returns false' do
-          comment_range = processed_source.find_token(&:comment?).pos
-          expect(processed_source.commented?(comment_range)).to be true
-        end
+      context 'provided source_range on line with comment' do
+        let(:range) { processed_source.find_token(&:comment?).pos }
+
+        it { is_expected.to be true }
       end
     end
 


### PR DESCRIPTION
`ProcessedSource#commented?` was only considering the beginning line of the given range