### PR TITLE
Simplify and optimize.

### DIFF
--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -130,6 +130,8 @@ module RuboCop
         PARAM_NUMBER = /%\d*/.freeze
 
         SEPARATORS = /\s+/.freeze
+        ONLY_SEPARATOR = /\A#{SEPARATORS}\Z/.freeze
+
         TOKENS     = Regexp.union(META, PARAM_CONST, KEYWORD_NAME, PARAM_NUMBER, NUMBER,
                                   METHOD_NAME, SYMBOL, STRING)
 
@@ -773,7 +775,7 @@ module RuboCop
         end
 
         def self.tokens(pattern)
-          pattern.scan(TOKEN).reject { |token| token =~ /\A#{SEPARATORS}\Z/ }
+          pattern.scan(TOKEN).grep_v(ONLY_SEPARATOR)
         end
 
         def def_helper(base, method_name, **defaults)


### PR DESCRIPTION
This reduces memory allocation from 19MB to 1.9MB (when run on cop/mixin).

Main issue remains that it is called way too many times though