### PR TITLE
CI: Split internal_investigation as its own CI job

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,6 +21,7 @@ jobs:
         rubocop: [ master ]
         coverage: [ null ]
         modern: [ null ]
+        internal_investigation: [ null ]
         title: [ null ]
         include:
           - { os: windows, rubocop: master, ruby: mingw }
@@ -28,6 +29,7 @@ jobs:
           - { rubocop: '0.84.0', ruby: head, os: ubuntu }
           - { rubocop: '0.84.0', ruby: 2.4, os: ubuntu, coverage: true, title: 'Cov' }
           - { rubocop: master, ruby: 2.7, os: ubuntu, modern: true, title: 'Modern' }
+          - { rubocop: master, ruby: 2.7, os: ubuntu, internal_investigation: true, modern: true, title: 'Style' }
 
     steps:
       - name: windows misc
@@ -68,10 +70,10 @@ jobs:
         if: matrix.modern == true
         run: echo '::set-env name=MODERNIZE::true'
       - name: spec
-        if: matrix.coverage != true
+        if: "matrix.coverage != true && matrix.internal_investigation != true"
         run:  bundle exec rake spec
       - name: internal_investigation
-        if: "matrix.os != 'windows' && matrix.coverage != true && matrix.rubocop == 'master'"
+        if: matrix.internal_investigation
         run:  bundle exec rake internal_investigation
   rubocop_specs:
     name: >-

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 jobs:
   ast_specs:
     name: >-
-      ${{ matrix.title || 'AST' }} | ${{ matrix.rubocop }} | ${{ matrix.ruby }} (${{ matrix.os }})
+      ${{ matrix.title || 'Specs' }} | RuboCop: ${{ matrix.rubocop }} | ${{ matrix.ruby }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     env:
       # See https://github.com/tmm1/test-queue#environment-variables
@@ -27,9 +27,9 @@ jobs:
           - { os: windows, rubocop: master, ruby: mingw }
           - { rubocop: '0.84.0', ruby: 2.4, os: ubuntu }
           - { rubocop: '0.84.0', ruby: head, os: ubuntu }
-          - { rubocop: '0.84.0', ruby: 2.4, os: ubuntu, coverage: true, title: 'Cov' }
-          - { rubocop: master, ruby: 2.7, os: ubuntu, modern: true, title: 'Modern' }
-          - { rubocop: master, ruby: 2.7, os: ubuntu, internal_investigation: true, modern: true, title: 'Style' }
+          - { rubocop: '0.84.0', ruby: 2.4, os: ubuntu, coverage: true, title: 'Coverage' }
+          - { rubocop: master, ruby: 2.7, os: ubuntu, modern: true, title: 'Specs "modern"' }
+          - { rubocop: master, ruby: 2.7, os: ubuntu, internal_investigation: true, modern: true, title: 'Coding Style' }
 
     steps:
       - name: windows misc
@@ -66,18 +66,18 @@ jobs:
         with:
           coverageCommand: bundle exec rake spec
           debug: true
-      - name: Set modernize mode
+      - name: set modernize mode
         if: matrix.modern == true
         run: echo '::set-env name=MODERNIZE::true'
       - name: spec
         if: "matrix.coverage != true && matrix.internal_investigation != true"
         run:  bundle exec rake spec
-      - name: internal_investigation
+      - name: internal investigation
         if: matrix.internal_investigation
         run:  bundle exec rake internal_investigation
   rubocop_specs:
     name: >-
-      Main | ${{ matrix.rubocop }} | ${{ matrix.ruby }} (${{ matrix.os }})
+      Main Gem Specs | RuboCop: ${{ matrix.rubocop }} | ${{ matrix.ruby }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}-latest
     env:
       # See https://github.com/tmm1/test-queue#environment-variables


### PR DESCRIPTION
This way it's very clear if a PR fails because of the content of the code, or its styling.