### PR TITLE
Fix `ProcessedSource` for cases with syntax errors

### DIFF
--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -168,10 +168,12 @@ module RuboCop
           ast ||= nil # force `false` to `nil`, see https://github.com/whitequark/parser/pull/722
         rescue Parser::SyntaxError
           # All errors are in diagnostics. No need to handle exception.
+          comments = []
+          tokens = []
         end
 
         ast&.complete!
-        tokens = tokens.map { |t| Token.from_parser_token(t) } if tokens
+        tokens = tokens.map { |t| Token.from_parser_token(t) }
 
         [ast, comments, tokens]
       end

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -165,12 +165,12 @@ module RuboCop
       def tokenize(parser)
         begin
           ast, comments, tokens = parser.tokenize(@buffer)
-
-          ast.respond_to?(:complete!) && ast.complete!
+          ast ||= nil # force `false` to `nil`, see https://github.com/whitequark/parser/pull/722
         rescue Parser::SyntaxError
           # All errors are in diagnostics. No need to handle exception.
         end
 
+        ast&.complete!
         tokens = tokens.map { |t| Token.from_parser_token(t) } if tokens
 
         [ast, comments, tokens]


### PR DESCRIPTION
In some circumstances, `ast` could be `false` instead of `nil`, `comments` and `tokens` could be `nil` instead of `[]`.