### PR TITLE
Review comments API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#85](https://github.com/rubocop-hq/rubocop-ast/pull/85): Add `IntNode#value` and `FloatNode#value`. ([@fatkodima][])
 * [#82](https://github.com/rubocop-hq/rubocop-ast/pull/82): `NodePattern`: Allow comments ([@marcandre][])
 * [#83](https://github.com/rubocop-hq/rubocop-ast/pull/83): Add `ProcessedSource#comment_at_line` ([@marcandre][])
+* [#83](https://github.com/rubocop-hq/rubocop-ast/pull/83): Add `ProcessedSource#each_comment_in_lines` ([@marcandre][])
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#70](https://github.com/rubocop-hq/rubocop-ast/pull/70): Add `NextNode` ([@marcandre][])
 * [#85](https://github.com/rubocop-hq/rubocop-ast/pull/85): Add `IntNode#value` and `FloatNode#value`. ([@fatkodima][])
 * [#82](https://github.com/rubocop-hq/rubocop-ast/pull/82): `NodePattern`: Allow comments ([@marcandre][])
+* [#83](https://github.com/rubocop-hq/rubocop-ast/pull/83): Add `ProcessedSource#comment_at_line` ([@marcandre][])
 
 ### Bug fixes
 

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -76,7 +76,7 @@ module RuboCop
         comments.each(&block)
       end
 
-      # @deprecated Use `comments.find`
+      # @deprecated Use `comments.find` or `comment_at_line`
       def find_comment(&block)
         comments.find(&block)
       end
@@ -99,9 +99,14 @@ module RuboCop
         ast.nil?
       end
 
+      # @return [Comment, nil] the comment at that line, if any.
+      def comment_at_line(line)
+        comment_index[line]
+      end
+
       # @return [Boolean] if the given line number has a comment.
       def line_with_comment?(line)
-        comment_lines.include?(line)
+        comment_index.include?(line)
       end
 
       # @return [Boolean] if any of the lines in the given `source_range` has a comment.
@@ -144,8 +149,10 @@ module RuboCop
 
       private
 
-      def comment_lines
-        @comment_lines ||= comments.map { |c| c.location.line }
+      def comment_index
+        @comment_index ||= {}.tap do |hash|
+          comments.each { |c| hash[c.location.line] = c }
+        end
       end
 
       def parse(source, ruby_version)

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -268,6 +268,15 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
     end
 
+    describe '#each_comment_in_lines' do
+      it 'yields the comments' do
+        enum = processed_source.each_comment_in_lines(1..4)
+        expect(enum.is_a?(Enumerable)).to be(true)
+        expect(enum.to_a).to eq processed_source.comments
+        expect(processed_source.each_comment_in_lines(2..5).map(&:text)).to eq ['# comment two']
+      end
+    end
+
     describe '#line_with_comment?' do
       it 'returns true for lines with comments' do
         expect(processed_source.line_with_comment?(1)).to be true

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -257,6 +257,17 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
     end
 
+    describe '#comment_at_line' do
+      it 'returns the comment at the given line number' do
+        expect(processed_source.comment_at_line(1).text).to eq '# comment one'
+        expect(processed_source.comment_at_line(4).text).to eq '# comment two'
+      end
+
+      it 'returns nil if line has no comment' do
+        expect(processed_source.comment_at_line(3)).to be nil
+      end
+    end
+
     describe '#line_with_comment?' do
       it 'returns true for lines with comments' do
         expect(processed_source.line_with_comment?(1)).to be true


### PR DESCRIPTION
This PR:
* Adds `ProcessedSource#comment_at_line`
* Adds `ProcessedSource#each_comment_in_lines`

It deprecates `ProcessedSource#comments_before_line` (which is imo a big code smell).

I can't believe how much time I spent to arrive to this quite small PR; it's like version 5.0, I was really slow to get to this API.

I have reviewed / fixed all uses of any comment-accessing method in the main gem. The PR is upcomming. My main take is that any PR that autocorrects any range that could span more than one line must have specs with comments *on each single line* (close to that range).