### PR TITLE
Add `Parser::Source::Range#line_span`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#82](https://github.com/rubocop-hq/rubocop-ast/pull/82): `NodePattern`: Allow comments ([@marcandre][])
 * [#83](https://github.com/rubocop-hq/rubocop-ast/pull/83): Add `ProcessedSource#comment_at_line` ([@marcandre][])
 * [#83](https://github.com/rubocop-hq/rubocop-ast/pull/83): Add `ProcessedSource#each_comment_in_lines` ([@marcandre][])
+* [#84](https://github.com/rubocop-hq/rubocop-ast/pull/84): Add `Source::Range#line_span` ([@marcandre][])
 
 ### Bug fixes
 

--- a/lib/rubocop/ast.rb
+++ b/lib/rubocop/ast.rb
@@ -4,6 +4,7 @@ require 'parser'
 require 'forwardable'
 require 'set'
 
+require_relative 'ast/ext/range'
 require_relative 'ast/node_pattern'
 require_relative 'ast/sexp'
 require_relative 'ast/node'

--- a/lib/rubocop/ast/ext/range.rb
+++ b/lib/rubocop/ast/ext/range.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module AST
+    module Ext
+      # Extensions to Parser::AST::Range
+      module Range
+        # @return [Range] the range of line numbers for the node
+        # If `exclude_end` is `true`, then the range will be exclusive.
+        #
+        # Assume that `node` corresponds to the following array literal:
+        #
+        #   [
+        #     :foo,
+        #     :bar
+        #   ]
+        #
+        #   node.loc.begin.line_span                         # => 1..1
+        #   node.loc.expression.line_span(exclude_end: true) # => 1...4
+        def line_span(exclude_end: false)
+          ::Range.new(first_line, last_line, exclude_end)
+        end
+      end
+    end
+  end
+end
+
+::Parser::Source::Range.include ::RuboCop::AST::Ext::Range

--- a/spec/rubocop/ast/ext/range_spec.rb
+++ b/spec/rubocop/ast/ext/range_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::AST::Ext::Range do
+  let(:source) { <<~RUBY }
+    [
+      1,
+      2
+    ]
+  RUBY
+
+  let(:node) { parse_source(source).ast }
+
+  describe '#line_span' do
+    it 'returns the range of lines a range occupies' do
+      expect(node.loc.begin.line_span).to eq 1..1
+    end
+
+    it 'accepts an `exclude_end` keyword argument' do
+      expect(node.loc.expression.line_span(exclude_end: true)).to eq 1...4
+    end
+  end
+end


### PR DESCRIPTION
I've seen about 20 occurrences of `range.{first}line..{.}range.last_line` or calls to `line_range(node)` (defined in `util.rb`)

I feel the name `line_span` is more descriptive and is less confusing with `Source::Buffer#line_range` which returns a range of columns for the given line.

I notice that there currently are no extension to `parser`'s classes, but this one seems reasonable.

The result can be particularly useful when dealing with comments, say with `each_comment_in_lines` of #83