### PR TITLE
`PairNode#delimiter` and `inverse_delimiter` now accept their argument as a named argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * [#70](https://github.com/rubocop-hq/rubocop-ast/pull/70): Fix arguments processing for `BreakNode` ([@marcandre][])
 * [#70](https://github.com/rubocop-hq/rubocop-ast/pull/70): **(Potentially breaking)** `BreakNode` and `ReturnNode` no longer include `MethodDispatchNode`. These methods were severely broken ([@marcandre][])
 
+### Changes
+
+* [#86](https://github.com/rubocop-hq/rubocop-ast/pull/86): `PairNode#delimiter` and `inverse_delimiter` now accept their argument as a named argument. ([@marcandre][])
+
 ## 0.2.0 (2020-07-19)
 
 ### New features

--- a/lib/rubocop/ast/node/case_match_node.rb
+++ b/lib/rubocop/ast/node/case_match_node.rb
@@ -16,12 +16,10 @@ module RuboCop
       end
 
       # @deprecated Use `in_pattern_branches.each`
-      def each_in_pattern
+      def each_in_pattern(&block)
         return in_pattern_branches.to_enum(__method__) unless block_given?
 
-        in_pattern_branches.each do |condition|
-          yield condition
-        end
+        in_pattern_branches.each(&block)
 
         self
       end

--- a/lib/rubocop/ast/node/case_node.rb
+++ b/lib/rubocop/ast/node/case_node.rb
@@ -16,12 +16,10 @@ module RuboCop
       end
 
       # @deprecated Use `when_branches.each`
-      def each_when
+      def each_when(&block)
         return when_branches.to_enum(__method__) unless block_given?
 
-        when_branches.each do |condition|
-          yield condition
-        end
+        when_branches.each(&block)
 
         self
       end

--- a/lib/rubocop/ast/node/hash_node.rb
+++ b/lib/rubocop/ast/node/hash_node.rb
@@ -56,12 +56,10 @@ module RuboCop
       #
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
-      def each_key
+      def each_key(&block)
         return pairs.map(&:key).to_enum unless block_given?
 
-        pairs.map(&:key).each do |key|
-          yield key
-        end
+        pairs.map(&:key).each(&block)
 
         self
       end
@@ -82,12 +80,10 @@ module RuboCop
       #
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
-      def each_value
+      def each_value(&block)
         return pairs.map(&:value).to_enum unless block_given?
 
-        pairs.map(&:value).each do |value|
-          yield value
-        end
+        pairs.map(&:value).each(&block)
 
         self
       end

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -158,12 +158,10 @@ module RuboCop
       end
 
       # @deprecated Use `branches.each`
-      def each_branch
+      def each_branch(&block)
         return branches.to_enum(__method__) unless block_given?
 
-        branches.each do |branch|
-          yield branch
-        end
+        branches.each(&block)
       end
     end
   end

--- a/lib/rubocop/ast/node/pair_node.rb
+++ b/lib/rubocop/ast/node/pair_node.rb
@@ -32,7 +32,7 @@ module RuboCop
       #
       # @param [Boolean] with_spacing whether to include spacing
       # @return [String] the delimiter of the `pair`
-      def delimiter(with_spacing = false)
+      def delimiter(*deprecated, with_spacing: deprecated.first)
         if with_spacing
           hash_rocket? ? SPACED_HASH_ROCKET : SPACED_COLON
         else
@@ -44,7 +44,7 @@ module RuboCop
       #
       # @param [Boolean] with_spacing whether to include spacing
       # @return [String] the inverse delimiter of the `pair`
-      def inverse_delimiter(with_spacing = false)
+      def inverse_delimiter(*deprecated, with_spacing: deprecated.first)
         if with_spacing
           hash_rocket? ? SPACED_COLON : SPACED_HASH_ROCKET
         else

--- a/lib/rubocop/ast/node/when_node.rb
+++ b/lib/rubocop/ast/node/when_node.rb
@@ -14,12 +14,10 @@ module RuboCop
       end
 
       # @deprecated Use `conditions.each`
-      def each_condition
+      def each_condition(&block)
         return conditions.to_enum(__method__) unless block_given?
 
-        conditions.each do |condition|
-          yield condition
-        end
+        conditions.each(&block)
 
         self
       end

--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -455,7 +455,6 @@ module RuboCop
           [0..Float::INFINITY, 'true']
         end
 
-        # rubocop:disable Metrics/AbcSize
         # rubocop:disable Metrics/MethodLength
         def compile_any_order(capture_all = nil)
           rest = capture_rest = nil
@@ -475,7 +474,6 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics/MethodLength
-        # rubocop:enable Metrics/AbcSize
 
         def insure_same_captures(enum, what)
           return to_enum __method__, enum, what unless block_given?

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -72,23 +72,23 @@ module RuboCop
       end
 
       # @deprecated Use `comments.each`
-      def each_comment
-        comments.each { |comment| yield comment }
+      def each_comment(&block)
+        comments.each(&block)
       end
 
       # @deprecated Use `comments.find`
-      def find_comment
-        comments.find { |comment| yield comment }
+      def find_comment(&block)
+        comments.find(&block)
       end
 
       # @deprecated Use `tokens.each`
-      def each_token
-        tokens.each { |token| yield token }
+      def each_token(&block)
+        tokens.each(&block)
       end
 
       # @deprecated Use `tokens.find`
-      def find_token
-        tokens.find { |token| yield token }
+      def find_token(&block)
+        tokens.find(&block)
       end
 
       def file_path

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -1468,6 +1468,7 @@ RSpec.describe RuboCop::AST::NodePattern do
   describe 'funcalls' do
     module RuboCop
       module AST
+        # Add test function calls
         class NodePattern
           def goodmatch(_foo)
             true

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RuboCop::AST::Node do
     before :all do
       module RuboCop
         module AST
+          # Patch Node
           class Node
             # Let's make our predicate matchers read better
             def used?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,12 +30,14 @@ RSpec.shared_context 'ruby 2.7', :ruby27 do
   let(:ruby_version) { 2.7 }
 end
 
+# ...
 module DefaultRubyVersion
   extend RSpec::SharedContext
 
   let(:ruby_version) { 2.4 }
 end
 
+# ...
 module ParseSourceHelper
   def parse_source(source)
     RuboCop::AST::ProcessedSource.new(source, ruby_version, nil)


### PR DESCRIPTION
Also, fix build.