### PR TITLE
Support right hand assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#83](https://github.com/rubocop-hq/rubocop-ast/pull/83): Add `ProcessedSource#each_comment_in_lines` ([@marcandre][])
 * [#84](https://github.com/rubocop-hq/rubocop-ast/pull/84): Add `Source::Range#line_span` ([@marcandre][])
 * [#87](https://github.com/rubocop-hq/rubocop-ast/pull/87): Add `CaseNode#branches` ([@marcandre][])
+* [#89](https://github.com/rubocop-hq/rubocop-ast/pull/89): Support `mrasgn` has the same structure as `masgn` except that the child nodes are reversed for Ruby 2.8 (3.0) parser. ([@koic][])
 
 ### Bug fixes
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -38,7 +38,7 @@ module RuboCop
       IMMUTABLE_LITERALS = (LITERALS - MUTABLE_LITERALS).freeze
 
       EQUALS_ASSIGNMENTS = %i[lvasgn ivasgn cvasgn gvasgn
-                              casgn masgn].freeze
+                              casgn masgn rasgn mrasgn].freeze
       SHORTHAND_ASSIGNMENTS = %i[op_asgn or_asgn and_asgn].freeze
       ASSIGNMENTS = (EQUALS_ASSIGNMENTS + SHORTHAND_ASSIGNMENTS).freeze
 

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -28,7 +28,7 @@ module RuboCop
                              arg_expr pin match_rest if_guard unless_guard
                              match_with_trailing_comma].freeze
       MANY_CHILD_NODES  = %i[dstr dsym xstr regexp array hash pair
-                             mlhs masgn or_asgn and_asgn
+                             mlhs masgn or_asgn and_asgn rasgn mrasgn
                              undef alias args super yield or and
                              while_post until_post iflipflop eflipflop
                              match_with_lvasgn begin kwbegin return


### PR DESCRIPTION
This PR supports right hand assignment for Ruby 2.8.0-dev (Ruby 3.0).
https://github.com/whitequark/parser/pull/682

## `mrasgn` vs `masgn`

`mrasgn` has the same structure as `masgn` except that the child nodes are reversed. So this PR adds `mrasgn` to the same constant as `masgn`.

### `mrasign`

```console
% ruby-parse -e '13.divmod(5) => a, b'
warning: parser/current is loading parser/ruby28, which recognizes
warning: 2.8.0-dev-compliant syntax, but you are running 2.8.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(mrasgn
  (send
    (int 13) :divmod
    (int 5))
  (mlhs
    (lvasgn :a)
    (lvasgn :b)))
```

### `masign`

```console
% ruby-parse -e 'a, b = 13.divmod(5)'
warning: parser/current is loading parser/ruby28, which recognizes
warning: 2.8.0-dev-compliant syntax, but you are running 2.8.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(masgn
  (mlhs
    (lvasgn :a)
    (lvasgn :b))
  (send
    (int 13) :divmod
    (int 5)))
```

## `rasgn`

`rasgn` has the same structure as `mrasgn` without `mlhs`.

```console
% ruby-parse -e '13.divmod(5) => a'
warning: parser/current is loading parser/ruby28, which recognizes
warning: 2.8.0-dev-compliant syntax, but you are running 2.8.0.
warning: please see
https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(rasgn
  (send
    (int 13) :divmod
    (int 5))
  (lvasgn :a))
```

So this PR adds `rasgn` to the same constant as `mrasgn`.
