### PR TITLE
In Ruby 2.4, `Set#===` is harmonized with Ruby 2.5+ to call `include?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#89](https://github.com/rubocop-hq/rubocop-ast/pull/89): Support right hand assignment for Ruby 2.8 (3.0) parser. ([@koic][])
 * [#93](https://github.com/rubocop-hq/rubocop-ast/pull/93): Add `Node#{left|right}_sibling{s}` ([@marcandre][])
 
+### Changes
+
+* [#94](https://github.com/rubocop-hq/rubocop-ast/pull/94): In Ruby 2.4, `Set#===` is harmonized with Ruby 2.5+ to call `include?`. ([@marcandre][])
+
 ## 0.3.0 (2020-08-01)
 
 ### New features

--- a/lib/rubocop/ast.rb
+++ b/lib/rubocop/ast.rb
@@ -5,6 +5,7 @@ require 'forwardable'
 require 'set'
 
 require_relative 'ast/ext/range'
+require_relative 'ast/ext/set'
 require_relative 'ast/node_pattern'
 require_relative 'ast/sexp'
 require_relative 'ast/node'

--- a/lib/rubocop/ast/ext/set.rb
+++ b/lib/rubocop/ast/ext/set.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+test = :foo
+case test
+when Set[:foo]
+  # ok, RUBY_VERSION > 2.4
+else
+  # Harmonize `Set#===`
+  class Set
+    alias === include?
+  end
+end

--- a/spec/rubocop/ast/ext/set_spec.rb
+++ b/spec/rubocop/ast/ext/set_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/DescribeClass, Style/CaseEquality
+RSpec.describe 'Set#===' do
+  it 'tests for inclusion' do
+    expect(Set[1, 2, 3] === 2).to eq true
+  end
+end
+# rubocop:enable RSpec/DescribeClass, Style/CaseEquality


### PR DESCRIPTION
This makes it possible to use `Set` in `NodePattern` on all supported Ruby versions.

cc @bbatsov 

