### PR TITLE
Fix typo in node pattern defining method name

### DIFF
--- a/docs/modules/ROOT/pages/node_pattern.adoc
+++ b/docs/modules/ROOT/pages/node_pattern.adoc
@@ -336,8 +336,8 @@ Example patterns using this function:
 The arguments can be pattern themselves, in which case a matcher responding to `===` will be passed. This makes patterns composable:
 
 ```ruby
-def_node_pattern :global_const?, '(const {nil? cbase} %1)'
-def_node_pattern :class_creator, '(send #global_const?({:Class :Module}) :new ...)'
+def_node_matcher :global_const?, '(const {nil? cbase} %1)'
+def_node_matcher :class_creator, '(send #global_const?({:Class :Module}) :new ...)'
 ```
 
 == Using node matcher macros

--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -205,7 +205,7 @@ module RuboCop
 
         def initialize(str, root = 'node0', node_var = root)
           @string   = str
-          # For def_node_pattern, root == node_var
+          # For def_node_matcher, root == node_var
           # For def_node_search, root is the root node to search on,
           # and node_var is the current descendant being searched.
           @root     = root


### PR DESCRIPTION
Should be `def_node_matcher`, not `def_node_pattern`. At least, I couldn't find the latter being defined anywhere.