### PR TITLE
Add RuboCop and extensions for local dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem 'bump', require: false
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.7'
+gem 'rubocop', '~> 0.89'
+gem 'rubocop-performance', '~> 1.0'
+gem 'rubocop-rspec', '~> 1.0'
 # Workaround for cc-test-reporter with SimpleCov 0.18.
 # Stop upgrading SimpleCov until the following issue will be resolved.
 # https://github.com/codeclimate/test-reporter/issues/418


### PR DESCRIPTION
Otherwise, it's impossible to run `rubocop` locally.

For frequent contributors those gems are already packed in `Gemfile.local`, but for first-time contributors it's not the case.