### PR TITLE
Fix `ConstNode#absolute?` raising `NoMethodError` when the constant is not namespaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bug fixes
+* [#115](https://github.com/rubocop-hq/rubocop-ast/pull/115): Fix `ConstNode#absolute?` when the constant is not namespaced. ([@dvandersluis][])
+
 ## 0.4.0 (2020-09-11)
 
 ### New features
@@ -97,3 +100,4 @@
 [@owst]: https://github.com/owst
 [@fatkodima]: https://github.com/fatkodima
 [@koic]: https://github.com/koic
+[@dvandersluis]: https://github.com/dvandersluis

--- a/lib/rubocop/ast/node/const_node.rb
+++ b/lib/rubocop/ast/node/const_node.rb
@@ -28,6 +28,8 @@ module RuboCop
 
       # @return [Boolean] if the constant starts with `::` (aka s(:cbase))
       def absolute?
+        return false unless namespace
+
         each_path.first.cbase_type?
       end
 

--- a/spec/rubocop/ast/const_node_spec.rb
+++ b/spec/rubocop/ast/const_node_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe RuboCop::AST::ConstNode do
 
       it { expect(const_node.absolute?).to eq false }
     end
+
+    context 'with a non-namespaced constant' do
+      let(:source) { 'Foo' }
+
+      it { expect(const_node.absolute?).to eq false }
+    end
+  end
+
+  describe '#relative?' do
+    context 'with a non-namespaced constant' do
+      let(:source) { 'Foo' }
+
+      it { expect(const_node.relative?).to eq true }
+    end
   end
 
   describe '#each_path' do


### PR DESCRIPTION
Came up in https://github.com/rubocop-hq/rubocop/pull/8738.

When there is no namespace, `each_path.first` is nil, which caused

```
NoMethodError: undefined method `cbase_type?' for nil:NilClass
```