### PR TITLE
Use stable sort when sorting tokens

### DIFF
--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -269,7 +269,8 @@ module RuboCop
       # is passed as a method argument. In this case tokens are interleaved by
       # heredoc contents' tokens.
       def sorted_tokens
-        @sorted_tokens ||= tokens.sort_by(&:begin_pos)
+        # Use stable sort.
+        @sorted_tokens ||= tokens.sort_by.with_index { |token, i| [token.begin_pos, i] }
       end
 
       def source_range(range_or_node)


### PR DESCRIPTION
For context - https://github.com/rubocop-hq/rubocop/pull/8729