### PR TITLE
Fix macro?

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -25,9 +25,9 @@ jobs:
         title: [ null ]
         include:
           - { os: windows, rubocop: master, ruby: mingw }
-          - { rubocop: '0.89.0', ruby: 2.4, os: ubuntu }
-          - { rubocop: '0.89.0', ruby: head, os: ubuntu }
-          - { rubocop: '0.89.0', ruby: 2.4, os: ubuntu, coverage: true, title: 'Coverage' }
+          - { rubocop: '0.92.0', ruby: 2.4, os: ubuntu }
+          - { rubocop: '0.92.0', ruby: head, os: ubuntu }
+          - { rubocop: '0.92.0', ruby: 2.4, os: ubuntu, coverage: true, title: 'Coverage' }
           - { rubocop: master, ruby: 2.7, os: ubuntu, modern: true, title: 'Specs "modern"' }
           - { rubocop: master, ruby: 2.7, os: ubuntu, internal_investigation: true, modern: true, title: 'Coding Style' }
 
@@ -87,7 +87,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         ruby: [ 2.4, 2.7 ]
-        rubocop: [ '0.89.0', master ]
+        rubocop: [ '0.92.0', master ]
 
     steps:
       - name: checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#120](https://github.com/rubocop-hq/rubocop-ast/pull/120): **(Potentially breaking)** Fix false positives and negatives for `SendNode#macro?`. This impacts `{non_}bare_access_modifier?` and `special_access_modifier?`. ([@marcandre][])
+
 ## 0.5.0 (2020-09-24)
 
 ### New features

--- a/lib/rubocop/ast/rubocop_compatibility.rb
+++ b/lib/rubocop/ast/rubocop_compatibility.rb
@@ -7,7 +7,8 @@ module RuboCop
     # @api private
     module RuboCopCompatibility
       INCOMPATIBLE_COPS = {
-        '0.89.0' => 'Layout/LineLength'
+        '0.89.0' => 'Layout/LineLength',
+        '0.92.0' => 'Style/MixinUsage'
       }.freeze
       def rubocop_loaded
         loaded = Gem::Version.new(RuboCop::Version::STRING)

--- a/spec/rubocop/ast/rubocop_compatibility_spec.rb
+++ b/spec/rubocop/ast/rubocop_compatibility_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::AST::RuboCopCompatibility do # rubocop:disable RSpec/Fil
   end
 
   context 'when ran from a compatible version of Rubocop' do
-    let(:rubocop_version) { '0.89.0' }
+    let(:rubocop_version) { '0.92.0' }
 
     it 'issues a warning' do
       expect { callback }.not_to output.to_stderr


### PR DESCRIPTION
This PR fixes rubocop-hq/rubocop#8765

There were many issues with how `macro_scope?`:
* recursion was badly written, so many cases were not handled well
* `if` did not distinguish if in the conditions part or on of the bodies

It also introduces `Node#parent?`

Builds on #119 

I'll do a final review when I'm less sleepy 😅