### PR TITLE
Update from `Parser::Ruby28` to `Parser::Ruby30` for Ruby 3.0 parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#121](https://github.com/rubocop-hq/rubocop-ast/pull/121): Update from `Parser::Ruby28` to `Parser::Ruby30` for Ruby 3.0 parser (experimental). ([@koic][])
+
 ## 0.4.2 (2020-09-18)
 
 ### Bug fixes

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -229,9 +229,9 @@ module RuboCop
         when 2.7
           require 'parser/ruby27'
           Parser::Ruby27
-        when 2.8
-          require 'parser/ruby28'
-          Parser::Ruby28
+        when 2.8, 3.0
+          require 'parser/ruby30'
+          Parser::Ruby30
         else
           raise ArgumentError,
                 "RuboCop found unknown Ruby version: #{ruby_version.inspect}"

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-ast/issues'
   }
 
-  s.add_runtime_dependency('parser', '>= 2.7.1.4')
+  s.add_runtime_dependency('parser', '>= 2.7.1.5')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 


### PR DESCRIPTION
Parser 2.7.1.5 includes https://github.com/whitequark/parser/pull/729 and this PR updates from `Parser::Ruby28` to `Parser::Ruby30` for Ruby 3.0 parser.