### PR TITLE
Avoid using `StringScanner#captures`, any `strscan` lib will do

### DIFF
--- a/lib/rubocop/ast/node_pattern/lexer.rb
+++ b/lib/rubocop/ast/node_pattern/lexer.rb
@@ -38,7 +38,7 @@ module RuboCop
 
         # @return [token]
         def emit(type)
-          value = ss.captures.first || ss.matched
+          value = ss[1] || ss.matched
           value = yield value if block_given?
           token = token(type, value)
           @tokens << token
@@ -50,7 +50,8 @@ module RuboCop
         end
 
         def emit_regexp
-          body, options = ss.captures
+          body = ss[1]
+          options = ss[2]
           flag = options.each_char.map { |c| REGEXP_OPTIONS[c] }.sum
 
           emit(:tREGEXP) { Regexp.new(body, flag) }

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -34,8 +34,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('parser', '>= 2.7.1.5')
 
-  s.add_runtime_dependency('strscan', '>= 1.0.0') # Ruby 2.4 doesn't provide `captures`
-
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 
   # #### Do NOT add `rubocop` (or anything depending on `rubocop`), even as a


### PR DESCRIPTION
Restores [compatibility with JRuby](https://github.com/jruby/jruby/issues/6414)