### PR TITLE
[Fixes #78] Make numblock behave similarly to block with equivalent arguments.

### DIFF
--- a/changelog/change_make_numblock_behave_similarly_to_block.md
+++ b/changelog/change_make_numblock_behave_similarly_to_block.md
@@ -1,0 +1,2 @@
+* [#78](https://github.com/rubocop-hq/rubocop-ast/issues/78): **(Potentially breaking)** `Block#arguments` now returns nodes for `numblock` (with no location) (Ruby 2.7+). ([@marcandre][])
+* [#78](https://github.com/rubocop-hq/rubocop-ast/issues/78): **(Potentially breaking)** `Traversal` now iterates on the arguments of `numblock` (Ruby 2.7+). ([@marcandre][])

--- a/changelog/fix_tweak_nodesource_so_it_does_not_crash_on.md
+++ b/changelog/fix_tweak_nodesource_so_it_does_not_crash_on.md
@@ -1,0 +1,1 @@
+* [#78](https://github.com/rubocop-hq/rubocop-ast/issues/78): Tweak `Node#source` so it does not crash on Nodes with no location. ([@marcandre][])

--- a/changelog/new_make_numblock_behave_similarly_to_block.md
+++ b/changelog/new_make_numblock_behave_similarly_to_block.md
@@ -1,0 +1,1 @@
+* [#78](https://github.com/rubocop-hq/rubocop-ast/issues/78): Add `Block#numbered_arguments` (Ruby 2.7+). ([@marcandre][])

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -83,6 +83,20 @@ module RuboCop
         value(token)
       end
 
+      # @api private
+      # @return [Node] A node corresponding to the equivalent block `:args` node
+      def self.numblock_arguments(numblock)
+        nb = numblock.children[1]
+        type = nb == 1 && emit_procarg0 ? :procarg0 : :arg
+        args = 1.upto(nb).map do |i|
+          Node.new(type, [:"_#{i}"])
+        end
+        node = ArgsNode.new(:args, args)
+        node.send :parent=, numblock
+        node.complete!
+        node
+      end
+
       private
 
       def node_klass(type)

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -238,9 +238,10 @@ module RuboCop
       end
 
       # Note: Some rare nodes may have no source, like `s(:args)` in `foo {}`
+      # or the `#arguments` of a `numblock`.
       # @return [String, nil]
       def source
-        loc.expression&.source
+        loc&.expression&.source
       end
 
       def source_range

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -195,6 +195,7 @@ module RuboCop
         children = node.children
         child = children[0]
         send(:"on_#{child.type}", child)
+        on_args(node.arguments)
         return unless (child = children[2])
 
         send(:"on_#{child.type}", child)

--- a/spec/rubocop/ast/block_node_spec.rb
+++ b/spec/rubocop/ast/block_node_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe RuboCop::AST::BlockNode do
 
     context '>= Ruby 2.7', :ruby27 do
       context 'using numbered parameters' do
-        let(:source) { 'foo { _1 }' }
+        let(:source) { 'foo { _1 + _3 }' }
 
-        it { expect(block_node.arguments.empty?).to be(true) }
+        it { expect(block_node.arguments.size).to eq(3) }
       end
     end
   end
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::AST::BlockNode do
       context 'using numbered parameters' do
         let(:source) { 'foo { _1 }' }
 
-        it { expect(block_node.arguments?).to be false }
+        it { expect(block_node.arguments?).to eq(true) }
       end
     end
   end

--- a/spec/rubocop/ast/traversal_spec.rb
+++ b/spec/rubocop/ast/traversal_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::AST::Traversal do
+  subject(:traverse) do
+    instance.walk(node)
+    instance
+  end
+
+  let(:ast) { parse_source(source).ast }
+  let(:instance) { klass.new }
+  let(:node) { ast }
+
+  context 'when a class defines on_arg', :ruby30 do
+    let(:klass) do
+      Class.new do
+        attr_reader :calls
+
+        include RuboCop::AST::Traversal
+        def on_arg(_node)
+          (@calls ||= []) << :on_arg
+          super
+        end
+      end
+    end
+
+    let(:source) { <<~RUBY }
+      42.times.map { _1 + _3 }
+    RUBY
+
+    it 'calls it for all arguments', :ruby30 do
+      expect(traverse.calls).to eq %i[on_arg on_arg on_arg]
+    end
+  end
+end

--- a/tasks/changelog.rb
+++ b/tasks/changelog.rb
@@ -21,9 +21,10 @@ class Changelog # rubocop:disable Metrics/ClassLength
 
   # New entry
   Entry = Struct.new(:type, :body, :ref_type, :ref_id, :user, keyword_init: true) do
-    def initialize(type:, body: last_commit_title, ref_type: :pull, ref_id: nil, user: github_user)
+    def initialize(type:, body: last_commit_title, ref_type: nil, ref_id: nil, user: github_user)
       id, body = extract_id(body)
       ref_id ||= id || 'x'
+      ref_type ||= id ? :issues : :pull
       super
     end
 
@@ -58,7 +59,7 @@ class Changelog # rubocop:disable Metrics/ClassLength
       str
         .downcase
         .split
-        .each { |s| s.gsub(/\W/, '') }
+        .map { |s| s.gsub(/\W/, '') }
         .reject(&:empty?)
         .inject do |result, word|
           s = "#{result}_#{word}"


### PR DESCRIPTION
This aims to make it easier to deal the same way with `foo { |x, y| bar(x, y) }` than with `foo { bar(_1, _2) }`.

`parser` generates an AST that is different with regards to the arguments:

```rb
# for a block:
s(:args s(:arg :x) s(:arg :y))

# for a numblock:
2
```

The method `BlockNode#arguments` return the same nodes as one would have, had it been written as `do |_1, _1| ...`, except there are no locations.

The module `Traversal` will visit these "virtual" `arguments`, even though they are not actually part of the children.

`BlockNode#numbered_arguments` return `nil` for a normal block, and `2` for the example with `_1` and `_2`; probably not particularly useful

`BlockNode#arguments?` now returns `true` for a `numblock`