### PR TITLE
Make `SendNode#macro?` aware of struct constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#141](https://github.com/rubocop-hq/rubocop-ast/pull/141): Make `SendNode#macro?` and `RuboCop::AST::Node#class_constructor?` aware of struct constructor and `RuboCop::AST::Node#struct_constructor?` is deprecated. ([@koic][])
+
 ## 1.0.0 (2020-10-21)
 
 ### Changes

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -484,10 +484,11 @@ module RuboCop
       def_node_matcher :global_const?, '(const {nil? cbase} %1)'
 
       def_node_matcher :class_constructor?, <<~PATTERN
-        {       (send #global_const?({:Class :Module}) :new ...)
-         (block (send #global_const?({:Class :Module}) :new ...) ...)}
+        {       (send #global_const?({:Class :Module :Struct}) :new ...)
+         (block (send #global_const?({:Class :Module :Struct}) :new ...) ...)}
       PATTERN
 
+      # @deprecated Use `:class_constructor?`
       def_node_matcher :struct_constructor?, <<~PATTERN
         (block (send #global_const?(:Struct) :new ...) _ $_)
       PATTERN

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -242,6 +242,17 @@ RSpec.describe RuboCop::AST::SendNode do
         it { expect(send_node).to be_macro }
       end
 
+      context 'when parent is a struct constructor' do
+        let(:source) do
+          ['Foo = Struct.new do',
+           '>>bar :baz<<',
+           '  bar :qux',
+           'end'].join("\n")
+        end
+
+        it { expect(send_node).to be_macro }
+      end
+
       context 'when parent is a singleton class' do
         let(:source) do
           ['class << self',


### PR DESCRIPTION
This PR makes `SendNode#macro?` aware of struct constructor.

Like class constructor, struct constructor will be recognized as a macro and will be awakened in the following `private` modifier:

```ruby
Foo = Struct.new(:foo) do
  private
    def private_foo
      foo
    end
end
```

With this change, this PR aims to resolve the following issue.
https://github.com/rubocop-hq/rubocop/issues/8919