### PR TITLE
Only traverse send nodes in def_modifier?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,3 +168,4 @@
 [@fatkodima]: https://github.com/fatkodima
 [@koic]: https://github.com/koic
 [@dvandersluis]: https://github.com/dvandersluis
+[@eugeneius]: https://github.com/eugeneius

--- a/changelog/fix_only_traverse_send_nodes_in_def_modifier.md
+++ b/changelog/fix_only_traverse_send_nodes_in_def_modifier.md
@@ -1,0 +1,1 @@
+* [#142](https://github.com/rubocop-hq/rubocop-ast/pull/142): Only traverse send nodes in `MethodDispatchNode#def_modifier?`. ([@eugeneius][])

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -174,7 +174,7 @@ module RuboCop
       # @return [Boolean] whether the dispatched method is a `def` modifier
       def def_modifier?
         send_type? &&
-          [self, *each_descendant(:send)].any?(&:adjacent_def_modifier?)
+          adjacent_def_modifier? || each_child_node(:send).any?(&:def_modifier?)
       end
 
       # Checks whether this is a lambda. Some versions of parser parses

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -1099,9 +1099,15 @@ RSpec.describe RuboCop::AST::SendNode do
     end
 
     context 'with several prefixed def modifiers' do
-      let(:source) { 'foo bar def baz; end' }
+      let(:source) { 'foo bar baz def qux; end' }
 
       it { expect(send_node).to be_def_modifier }
+    end
+
+    context 'with a block containing a method definition' do
+      let(:source) { 'foo bar { baz def qux; end }' }
+
+      it { expect(send_node).not_to be_def_modifier }
     end
   end
 


### PR DESCRIPTION
A send node is a "def modifier" if it's part of a chain of method calls preceding a method definition. However the previous implementation was too permissive and matched any method definition in the send node's AST.

In the following example, `include` was considered to be a def modifier:

```ruby
include Module.new {
  private def foo
  end
}
```

This is the root cause of the problem fixed in https://github.com/rubocop-hq/rubocop/pull/8653.