### PR TITLE
Fix node_pattern documentation path

### DIFF
--- a/docs/modules/ROOT/pages/node_pattern_compiler.adoc
+++ b/docs/modules/ROOT/pages/node_pattern_compiler.adoc
@@ -1,7 +1,7 @@
 = Hacker's guide to the `NodePattern` compiler
 
 This documentation is aimed at anyone wanting to understand / modify the `NodePattern` compiler.
-It assumes some familiarity with the syntax of https://github.com/rubocop-hq/rubocop-ast/blob/master/doc/modules/ROOT/pages/node_pattern.md[`NodePattern`], as well as the AST produced by the `parser` gem.
+It assumes some familiarity with the syntax of https://github.com/rubocop-hq/rubocop-ast/blob/master/docs/modules/ROOT/pages/node_pattern.adoc[`NodePattern`], as well as the AST produced by the `parser` gem.
 
 == High level view
 

--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -6,7 +6,7 @@ module RuboCop
   module AST
     # This class performs a pattern-matching operation on an AST node.
     #
-    # Detailed syntax: /doc/modules/ROOT/pages/node_pattern.md
+    # Detailed syntax: /docs/modules/ROOT/pages/node_pattern.adoc
     #
     # Initialize a new `NodePattern` with `NodePattern.new(pattern_string)`, then
     # pass an AST node to `NodePattern#match`. Alternatively, use one of the class

--- a/lib/rubocop/ast/node_pattern/builder.rb
+++ b/lib/rubocop/ast/node_pattern/builder.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Responsible to build the AST nodes for `NodePattern`
       #
       # Doc on how this fits in the compiling process:
-      #   /doc/modules/ROOT/pages/node_pattern.md
+      #   /docs/modules/ROOT/pages/node_pattern.adoc
       class Builder
         def emit_capture(capture_token, node)
           return node if capture_token.nil?

--- a/lib/rubocop/ast/node_pattern/compiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler.rb
@@ -7,7 +7,7 @@ module RuboCop
       # Defers work to its subcompilers
       #
       # Doc on how this fits in the compiling process:
-      #   /doc/modules/ROOT/pages/node_pattern.md
+      #   /docs/modules/ROOT/pages/node_pattern.adoc
       class Compiler
         extend Forwardable
         attr_reader :captures, :named_parameters, :positional_parameters, :binding

--- a/lib/rubocop/ast/node_pattern/compiler/atom_subcompiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/atom_subcompiler.rb
@@ -8,7 +8,7 @@ module RuboCop
         # This value responds to `===`.
         #
         # Doc on how this fits in the compiling process:
-        #   /doc/modules/ROOT/pages/node_pattern.md
+        #   /docs/modules/ROOT/pages/node_pattern.adoc
         class AtomSubcompiler < Subcompiler
           private
 

--- a/lib/rubocop/ast/node_pattern/compiler/node_pattern_subcompiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/node_pattern_subcompiler.rb
@@ -9,7 +9,7 @@ module RuboCop
         # or it's `node.type` if `seq_head` is true
         #
         # Doc on how this fits in the compiling process:
-        #   /doc/modules/ROOT/pages/node_pattern.md
+        #   /docs/modules/ROOT/pages/node_pattern.adoc
         class NodePatternSubcompiler < Subcompiler
           attr_reader :access, :seq_head
 

--- a/lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
@@ -11,7 +11,7 @@ module RuboCop
         # Assumes the given `var` is a `::RuboCop::AST::Node`
         #
         # Doc on how this fits in the compiling process:
-        #   /doc/modules/ROOT/pages/node_pattern.md
+        #   /docs/modules/ROOT/pages/node_pattern.adoc
         #
         # rubocop:disable Metrics/ClassLength
         class SequenceSubcompiler < Subcompiler

--- a/lib/rubocop/ast/node_pattern/compiler/subcompiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/subcompiler.rb
@@ -8,7 +8,7 @@ module RuboCop
         # Implements visitor pattern
         #
         # Doc on how this fits in the compiling process:
-        #   /doc/modules/ROOT/pages/node_pattern.md
+        #   /docs/modules/ROOT/pages/node_pattern.adoc
         class Subcompiler
           attr_reader :compiler
 

--- a/lib/rubocop/ast/node_pattern/lexer.rb
+++ b/lib/rubocop/ast/node_pattern/lexer.rb
@@ -14,7 +14,7 @@ module RuboCop
       # Lexer class for `NodePattern`
       #
       # Doc on how this fits in the compiling process:
-      #   /doc/modules/ROOT/pages/node_pattern.md
+      #   /docs/modules/ROOT/pages/node_pattern.adoc
       class Lexer < LexerRex
         Error = ScanError
 

--- a/lib/rubocop/ast/node_pattern/parser.rb
+++ b/lib/rubocop/ast/node_pattern/parser.rb
@@ -9,7 +9,7 @@ module RuboCop
       # Note: class reopened in `parser.racc`
       #
       # Doc on how this fits in the compiling process:
-      #   /doc/modules/ROOT/pages/node_pattern.md
+      #   /docs/modules/ROOT/pages/node_pattern.adoc
       class Parser < Racc::Parser
         extend Forwardable
 


### PR DESCRIPTION
Follow https://github.com/rubocop-hq/rubocop-ast/commit/2ca9c08b

This PR fixes node_pattern documentation path and recovers dead link on the following document page.
https://docs.rubocop.org/rubocop-ast/1.0/node_pattern_compiler.html