### PR TITLE
Fix `IfNode#branches` to return both branches when called on ternary conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 * [#144](https://github.com/rubocop-hq/rubocop-ast/pull/144): NodePattern: allow method calls on constants. ([@marcandre][])
 
+### Bug fixes
+
+* [#146](https://github.com/rubocop-hq/rubocop-ast/pull/146): Fix `IfNode#branches` to return both branches when called on ternary conditional. ([@fatkodima][])
+
 ## 1.0.1 (2020-10-23)
 
 ### Bug fixes

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -145,16 +145,19 @@ module RuboCop
       #
       # @return [Array<Node>] an array of branch nodes
       def branches
-        branches = [if_branch]
-
-        return branches unless else?
-
-        other_branches = if elsif_conditional?
-                           else_branch.branches
-                         else
-                           [else_branch]
-                         end
-        branches.concat(other_branches)
+        if ternary?
+          [if_branch, else_branch]
+        elsif !else?
+          [if_branch]
+        else
+          branches = [if_branch]
+          other_branches = if elsif_conditional?
+                             else_branch.branches
+                           else
+                             [else_branch]
+                           end
+          branches.concat(other_branches)
+        end
       end
 
       # @deprecated Use `branches.each`

--- a/spec/rubocop/ast/if_node_spec.rb
+++ b/spec/rubocop/ast/if_node_spec.rb
@@ -434,6 +434,13 @@ RSpec.describe RuboCop::AST::IfNode do
       it { expect(if_node.branches).to all(be_literal) }
     end
 
+    context 'with a ternary operator' do
+      let(:source) { 'foo? ? :foo : 42' }
+
+      it { expect(if_node.branches.size).to eq(2) }
+      it { expect(if_node.branches).to all(be_literal) }
+    end
+
     context 'with an unless statement' do
       let(:source) { 'unless foo?; :bar; end' }
 


### PR DESCRIPTION
Currently, it is returning only 1 branch.