### PR TITLE
`def_node_pattern` and `def_node_search` now return the method name.

### DIFF
--- a/changelog/change_def_node_pattern_and_def_node_search_now.md
+++ b/changelog/change_def_node_pattern_and_def_node_search_now.md
@@ -1,0 +1,1 @@
+* [#147](https://github.com/rubocop-hq/rubocop-ast/pull/147): `def_node_pattern` and `def_node_search` now return the method name. ([@marcandre][])

--- a/lib/rubocop/ast/node_pattern/method_definer.rb
+++ b/lib/rubocop/ast/node_pattern/method_definer.rb
@@ -56,6 +56,8 @@ module RuboCop
           end
           src = yield method_name
           base.class_eval(src, location.path, location.lineno)
+
+          method_name
         end
 
         def emit_node_search(method_name)

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -2054,9 +2054,10 @@ RSpec.describe RuboCop::AST::NodePattern do
 
     let(:keyword_defaults) { {} }
     let(:method_name) { :my_matcher }
-    let(:line_no) { __LINE__ + 2 }
+    let(:line_no) { __LINE__ + 1 }
+    let(:call_helper) { MyClass.public_send helper_name, method_name, pattern, **keyword_defaults }
     let(:defined_class) do
-      MyClass.public_send helper_name, method_name, pattern, **keyword_defaults
+      call_helper
       MyClass
     end
     let(:ruby) { ':hello' }
@@ -2075,6 +2076,10 @@ RSpec.describe RuboCop::AST::NodePattern do
 
       context 'def_node_matcher' do
         let(:helper_name) { :def_node_matcher }
+
+        it 'returns the method name' do
+          expect(call_helper).to eq method_name
+        end
 
         context 'when called on matching code' do
           it { expect(instance).to match_code(node) }
@@ -2098,6 +2103,10 @@ RSpec.describe RuboCop::AST::NodePattern do
       context 'def_node_search' do
         let(:helper_name) { :def_node_search }
         let(:ruby) { 'foo(:hello, :world)' }
+
+        it 'returns the method name' do
+          expect(call_helper).to eq method_name
+        end
 
         context('without a predicate name') do
           context 'when called on matching code' do


### PR DESCRIPTION
See https://github.com/rubocop-hq/rubocop/pull/7695