### PR TITLE
Disable `RSpec/MultipleMemoizedHelpers`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -108,3 +108,6 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/FactoryBot/CreateList:
   Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -103,7 +103,8 @@ RSpec/MessageSpies:
 RSpec/NestedGroups:
   Max: 7
 
-# RSpec/MultipleMemoizedHelpers:
-#   Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/FactoryBot/CreateList:
   Enabled: false


### PR DESCRIPTION
This single cop generates 372 offenses, e.g. "Example group has too many memoized helpers [19/5]"

https://github.com/rubocop-hq/rubocop-rspec/pull/863