### PR TITLE
Use refinements to support Ruby <= 2.6 Range#minmax

### DIFF
--- a/lib/rubocop/ast.rb
+++ b/lib/rubocop/ast.rb
@@ -5,6 +5,7 @@ require 'forwardable'
 require 'set'
 
 require_relative 'ast/ext/range'
+require_relative 'ast/ext/range_min_max'
 require_relative 'ast/ext/set'
 require_relative 'ast/node_pattern/method_definer'
 require_relative 'ast/node_pattern'

--- a/lib/rubocop/ast/ext/range_min_max.rb
+++ b/lib/rubocop/ast/ext/range_min_max.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module AST
+    module Ext
+      # Refinement to circumvent broken `Range#minmax` for infinity ranges in 2.6-
+      module RangeMinMax
+        if ::Range.instance_method(:minmax).owner != ::Range
+          refine ::Range do
+            def minmax
+              [min, max]
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cleans up the code and cleaner detection.

See [this discussion](https://github.com/rubocop-hq/rubocop-ast/pull/150#issuecomment-726865019)