### PR TITLE
Fix deprecating `set-env` for GitHub Actions

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.os == 'windows'
         run: |
           # set TMPDIR, git core.autocrlf
-          echo "::set-env name=TMPDIR::$env:RUNNER_TEMP"
+          echo "TMPDIR=$env:RUNNER_TEMP" >> $GITHUB_ENV
           git config --system core.autocrlf false
       - name: checkout
         uses: actions/checkout@v2
@@ -63,7 +63,7 @@ jobs:
           debug: true
       - name: set modernize mode
         if: matrix.modern == true
-        run: echo '::set-env name=MODERNIZE::true'
+        run: echo 'MODERNIZE=true' >> $GITHUB_ENV
       - name: independence check
         if: matrix.os != 'windows'
         run: (! bundle exec rubocop -h 2> /dev/null) && echo 'RuboCop successfully *not* loaded for local tests'
@@ -92,7 +92,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: setup env
-        run: echo '::set-env name=RUBOCOP_VERSION::${{ matrix.rubocop }}'
+        run: echo 'RUBOCOP_VERSION=${{ matrix.rubocop }}' >> $GITHUB_ENV
       - name: install rubocop from source for full specs
         run: git clone --branch ${{ matrix.rubocop }} https://github.com/rubocop-hq/rubocop.git ../rubocop
       - name: install rubocop dependencies

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -222,7 +222,7 @@ module RuboCop
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
       def each_ancestor(*types, &block)
-        return to_enum(__method__, *types) unless block_given?
+        return to_enum(__method__, *types) unless block
 
         visit_ancestors(types, &block)
 

--- a/lib/rubocop/ast/node/array_node.rb
+++ b/lib/rubocop/ast/node/array_node.rb
@@ -19,7 +19,7 @@ module RuboCop
 
       # @deprecated Use `values.each` (a.k.a. `children.each`)
       def each_value(&block)
-        return to_enum(__method__) unless block_given?
+        return to_enum(__method__) unless block
 
         values.each(&block)
 

--- a/lib/rubocop/ast/node/case_match_node.rb
+++ b/lib/rubocop/ast/node/case_match_node.rb
@@ -17,7 +17,7 @@ module RuboCop
 
       # @deprecated Use `in_pattern_branches.each`
       def each_in_pattern(&block)
-        return in_pattern_branches.to_enum(__method__) unless block_given?
+        return in_pattern_branches.to_enum(__method__) unless block
 
         in_pattern_branches.each(&block)
 

--- a/lib/rubocop/ast/node/case_node.rb
+++ b/lib/rubocop/ast/node/case_node.rb
@@ -17,7 +17,7 @@ module RuboCop
 
       # @deprecated Use `when_branches.each`
       def each_when(&block)
-        return when_branches.to_enum(__method__) unless block_given?
+        return when_branches.to_enum(__method__) unless block
 
         when_branches.each(&block)
 

--- a/lib/rubocop/ast/node/const_node.rb
+++ b/lib/rubocop/ast/node/const_node.rb
@@ -45,7 +45,7 @@ module RuboCop
       #      s(:const, :Foo), then
       #      s(:const, s(:const, :Foo), :Bar)
       def each_path(&block)
-        return to_enum(__method__) unless block_given?
+        return to_enum(__method__) unless block
 
         descendants = []
         last = self

--- a/lib/rubocop/ast/node/hash_node.rb
+++ b/lib/rubocop/ast/node/hash_node.rb
@@ -57,7 +57,7 @@ module RuboCop
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
       def each_key(&block)
-        return pairs.map(&:key).to_enum unless block_given?
+        return pairs.map(&:key).to_enum unless block
 
         pairs.map(&:key).each(&block)
 
@@ -81,7 +81,7 @@ module RuboCop
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
       def each_value(&block)
-        return pairs.map(&:value).to_enum unless block_given?
+        return pairs.map(&:value).to_enum unless block
 
         pairs.map(&:value).each(&block)
 

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -162,7 +162,7 @@ module RuboCop
 
       # @deprecated Use `branches.each`
       def each_branch(&block)
-        return branches.to_enum(__method__) unless block_given?
+        return branches.to_enum(__method__) unless block
 
         branches.each(&block)
       end

--- a/lib/rubocop/ast/node/mixin/descendence.rb
+++ b/lib/rubocop/ast/node/mixin/descendence.rb
@@ -59,7 +59,7 @@ module RuboCop
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
       def each_descendant(*types, &block)
-        return to_enum(__method__, *types) unless block_given?
+        return to_enum(__method__, *types) unless block
 
         visit_descendants(types, &block)
 
@@ -94,7 +94,7 @@ module RuboCop
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
       def each_node(*types, &block)
-        return to_enum(__method__, *types) unless block_given?
+        return to_enum(__method__, *types) unless block
 
         yield self if types.empty? || types.include?(type)
 

--- a/lib/rubocop/ast/node/when_node.rb
+++ b/lib/rubocop/ast/node/when_node.rb
@@ -15,7 +15,7 @@ module RuboCop
 
       # @deprecated Use `conditions.each`
       def each_condition(&block)
-        return conditions.to_enum(__method__) unless block_given?
+        return conditions.to_enum(__method__) unless block
 
         conditions.each(&block)
 

--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -103,7 +103,7 @@ module RuboCop
       # Yields its argument and any descendants, depth-first.
       #
       def self.descend(element, &block)
-        return to_enum(__method__, element) unless block_given?
+        return to_enum(__method__, element) unless block
 
         yield element
 

--- a/lib/rubocop/ast/node_pattern/lexer.rb
+++ b/lib/rubocop/ast/node_pattern/lexer.rb
@@ -52,7 +52,7 @@ module RuboCop
         def emit_regexp
           body = ss[1]
           options = ss[2]
-          flag = options.each_char.map { |c| REGEXP_OPTIONS[c] }.sum
+          flag = options.each_char.sum { |c| REGEXP_OPTIONS[c] }
 
           emit(:tREGEXP) { Regexp.new(body, flag) }
         end


### PR DESCRIPTION
This PR fixes the following GitHub Actions error.

```console
Run echo '::set-env name=RUBOCOP_VERSION::master'
Error: Unable to process command '::set-env
name=RUBOCOP_VERSION::master' successfully.
Error: The `set-env` command is disabled. Please upgrade to using
Environment Files or opt into unsecure command execution by setting the
`ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For
more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

https://github.com/rubocop-hq/rubocop-ast/pull/152/checks?check_run_id=1438579176