### PR TITLE
Enable `BlockNode#argument_list` for `numblock`s. 

### DIFF
--- a/changelog/change_enable_blocknodeargument_list_for.md
+++ b/changelog/change_enable_blocknodeargument_list_for.md
@@ -1,0 +1,1 @@
+* [#155](https://github.com/rubocop-hq/rubocop-ast/pull/155): Enable `BlockNode#argument_list` for `numblock`s. ([@dvandersluis][])

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -40,9 +40,11 @@ module RuboCop
       #
       # @return [Array<Node>]
       def argument_list
-        return [].freeze unless arguments?
-
-        arguments.argument_list
+        if numblock_type?
+          numbered_arguments
+        else
+          arguments.argument_list
+        end
       end
 
       # The body of this block.
@@ -129,6 +131,18 @@ module RuboCop
       # @return [Boolean] whether the `block` node body is a void context
       def void_context?
         VOID_CONTEXT_METHODS.include?(method_name)
+      end
+
+      private
+
+      # Numbered arguments of this `numblock`.
+      def numbered_arguments
+        return [].freeze unless numblock_type?
+
+        max_param = children[1]
+        1.upto(max_param).map do |i|
+          ArgNode.new(:arg, [:"_#{i}"])
+        end.freeze
       end
     end
   end


### PR DESCRIPTION
Follows #154 (I'll rebase away that commit once merged).

`numblock`s now return an array of `ArgNode`s from `BlockNode#argument_list`, ~and `BlockNode#arguments?` is true for `numblock`s.~