### PR TITLE
NodePattern now considers constant names to refer to constants

### DIFF
--- a/changelog/fix_nodepattern_now_considers_constant_names.md
+++ b/changelog/fix_nodepattern_now_considers_constant_names.md
@@ -1,0 +1,1 @@
+* [#156](https://github.com/rubocop-hq/rubocop-ast/issues/156): NodePattern now considers constant names to refer to constants (instead of predicate `#Example_type?`). ([@marcandre][])

--- a/docs/modules/ROOT/pages/node_pattern.adoc
+++ b/docs/modules/ROOT/pages/node_pattern.adoc
@@ -490,7 +490,7 @@ interesting_call?(node, method: /^transform/) # match anything starting with 'tr
 
 Named parameters as arguments to custom methods are also supported.
 
-== `%CONST` for constants
+== `CONST` or `%CONST` for constants
 
 Constants can be included in patterns. They will be matched using `===`, so
 +Regexp+ / +Set+ / +Proc+ can be used in addition to literals and +Nodes+:
@@ -501,7 +501,7 @@ SOME_CALLS = Set[:transform_values, :transform_keys,
                  :transform_values!, :transform_keys!,
                  :to_h].freeze
 
-def_node_matcher :interesting_call?, '(send _ %SOME_CALLS ...)'
+def_node_matcher :interesting_call?, '(send _ SOME_CALLS ...)'
 
 ----
 

--- a/lib/rubocop/ast/node_pattern/lexer.rex
+++ b/lib/rubocop/ast/node_pattern/lexer.rex
@@ -13,7 +13,8 @@ class RuboCop::AST::NodePattern::LexerRex
 macros
         CONST_NAME                /[A-Z:][a-zA-Z_:]+/
         SYMBOL_NAME               /[\w+@*\/?!<>=~|%^-]+|\[\]=?/
-        IDENTIFIER                /[a-zA-Z_][a-zA-Z0-9_-]*/
+        IDENTIFIER                /[a-z][a-zA-Z0-9_]*/
+        NODE_TYPE                 /[a-z][a-zA-Z0-9_-]*/  # Same as identifier but allows '-'
         CALL                      /(?:#{CONST_NAME}\.)?#{IDENTIFIER}[!?]?/
         REGEXP_BODY               /(?:[^\/]|\\\/)*/
         REGEXP                    /\/(#{REGEXP_BODY})(?<!\\)\/([imxo]*)/
@@ -27,14 +28,14 @@ rules
           %w"( ) { | } [ ] < > $ ! ^ ` ... + * ? ,"
         )}/o                      { emit ss.matched, &:to_sym }
         /#{REGEXP}/o              { emit_regexp }
-        /%(#{CONST_NAME})/o       { emit :tPARAM_CONST }
+        /%?(#{CONST_NAME})/o      { emit :tPARAM_CONST }
         /%([a-z_]+)/              { emit :tPARAM_NAMED }
         /%(\d*)/                  { emit(:tPARAM_NUMBER) { |s| s.empty? ? 1 : s.to_i } } # Map `%` to `%1`
         /_(#{IDENTIFIER})/o       { emit :tUNIFY }
         /_/o                      { emit :tWILDCARD }
         /\#(#{CALL})/o            { @state = :ARG; emit :tFUNCTION_CALL, &:to_sym }
         /#{IDENTIFIER}\?/o        { @state = :ARG; emit :tPREDICATE, &:to_sym }
-        /#{IDENTIFIER}/o          { emit :tNODE_TYPE, &:to_sym }
+        /#{NODE_TYPE}/o           { emit :tNODE_TYPE, &:to_sym }
   :ARG  /\(/                      { @state = nil; emit :tARG_LIST }
   :ARG  //                        { @state = nil }
         /\#.*/                    { emit_comment }

--- a/spec/rubocop/ast/block_node_spec.rb
+++ b/spec/rubocop/ast/block_node_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe RuboCop::AST::BlockNode do
       it { expect(names).to eq(%i[a b c d e f g h i]) }
     end
 
-    # rubocop:disable Naming/VariableNumber
     context '>= Ruby 2.7', :ruby27 do
       context 'using numbered parameters' do
         context 'with skipped params' do
@@ -82,7 +81,6 @@ RSpec.describe RuboCop::AST::BlockNode do
         end
       end
     end
-    # rubocop:enable Naming/VariableNumber
   end
 
   describe '#arguments?' do

--- a/spec/rubocop/ast/node_pattern/lexer_spec.rb
+++ b/spec/rubocop/ast/node_pattern/lexer_spec.rb
@@ -60,4 +60,17 @@ RSpec.describe RuboCop::AST::NodePattern::Lexer do
       expect { tokens }.to raise_error(RuboCop::AST::NodePattern::LexerRex::ScanError)
     end
   end
+
+  context 'when given node types and constants' do
+    let(:source) { '(aa bb Cc DD ::Ee Ff::GG %::Hh Zz %Zz)' }
+    let(:tokens) { super()[1...-1] }
+
+    it 'distinguishes them' do
+      types = tokens.map(&:first)
+      expect(types).to eq [:tNODE_TYPE] * 2 + [:tPARAM_CONST] * 7
+      zz, percent_zz = tokens.last(2).map(&:last).map(&:first)
+      expect(zz).to eq 'Zz'
+      expect(percent_zz).to eq 'Zz'
+    end
+  end
 end


### PR DESCRIPTION
(instead of predicate `#Example_type?`)

[Fixes #156]