### PR TITLE
Turn on 'emit_match_pattern'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ See the [docs site](https://docs.rubocop.org/rubocop-ast) for more details.
 
 ### Parser compatibility switches
 
-This gem, by default, uses most [legacy AST output from parser](https://github.com/whitequark/parser/#usage), except for `emit_forward_arg` which is set to `true`.
+This gem, by default, uses most [legacy AST output from parser](https://github.com/whitequark/parser/#usage), except for the following which are set to `true`:
+* `emit_forward_arg`
+* `emit_match_pattern`
 
 The main `RuboCop` gem uses these defaults (and is currently only compatible with these), but this gem can be used separately from `RuboCop` and is meant to be compatible with all settings. For example, to have `-> { ... }` emitted
 as `LambdaNode` instead of `SendNode`:

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -15,6 +15,7 @@ module RuboCop
     #   root_node = parser.parse(buffer)
     class Builder < Parser::Builders::Default
       self.emit_forward_arg = true
+      self.emit_match_pattern = true if respond_to?(:emit_match_pattern=)
 
       # @api private
       NODE_MAP = {

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -52,6 +52,7 @@ module RuboCop
         indexasgn:    IndexasgnNode,
         irange:       RangeNode,
         erange:       RangeNode,
+        kwargs:       HashNode,
         kwsplat:      KeywordSplatNode,
         lambda:       LambdaNode,
         module:       ModuleNode,

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -114,9 +114,10 @@ module RuboCop
                               in_match match_alt break next
                               match_as array_pattern array_pattern_with_tail
                               hash_pattern const_pattern find_pattern
-                              index indexasgn procarg0]
+                              index indexasgn procarg0 kwargs]
       many_opt_node_children = %i[case rescue resbody ensure for when
-                                  case_match in_pattern irange erange]
+                                  case_match in_pattern irange erange
+                                  match_pattern match_pattern_p]
 
       ### Callbacks for above
       def_callback no_children

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,9 @@ require 'rubocop-ast'
 if ENV['MODERNIZE']
   RuboCop::AST::Builder.modernize
   RuboCop::AST::Builder.emit_forward_arg = false # inverse of default
+  if RuboCop::AST::Builder.respond_to?(:emit_match_pattern=)
+    RuboCop::AST::Builder.emit_match_pattern = false # inverse of default
+  end
 end
 
 RSpec.shared_context 'ruby 2.3', :ruby23 do


### PR DESCRIPTION
This flag improves the API for Ruby 3.0; I don't think any cop was relying on pattern match `in` operator in Ruby 2.7 (was officially experimental)