### PR TITLE
Add a period to the end of a sentence in the documentation

### DIFF
--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -28,7 +28,7 @@ module RuboCop
       module Macros
         # Define a method which applies a pattern to an AST node
         #
-        # The new method will return nil if the node does not match
+        # The new method will return nil if the node does not match.
         # If the node matches, and a block is provided, the new method will
         # yield to the block (passing any captures as block arguments).
         # If the node matches, and no block is provided, the new method will


### PR DESCRIPTION
Now when this line is joined with the next line (as it will be on
[rubydoc.info](https://www.rubydoc.info/gems/rubocop-ast/RuboCop/AST/NodePattern/Macros#def_node_matcher-instance_method)), it won't turn into a run-on sentence.

See:
<img width="864" alt="Screen Shot 2021-02-14 at 3 49 47 PM" src="https://user-images.githubusercontent.com/4869194/107892970-4470c100-6edd-11eb-97e5-fbd88e8c4932.png">